### PR TITLE
adding marker property to ExLogRecord

### DIFF
--- a/src/main/java/org/jboss/logmanager/ExtLogRecord.java
+++ b/src/main/java/org/jboss/logmanager/ExtLogRecord.java
@@ -19,6 +19,7 @@ package org.jboss.logmanager;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.text.MessageFormat;
 import java.util.Map;
 import java.util.MissingResourceException;
@@ -118,6 +119,7 @@ public class ExtLogRecord extends LogRecord {
         hostName = original.hostName;
         processName = original.processName;
         processId = original.processId;
+        marker = original.marker;
     }
 
     /**
@@ -141,7 +143,7 @@ public class ExtLogRecord extends LogRecord {
     private transient boolean calculateCaller = true;
 
     private String ndc;
-    private FormatStyle formatStyle = FormatStyle.MESSAGE_FORMAT;
+    private FormatStyle formatStyle;
     private FastCopyHashMap<String, Object> mdcCopy;
     private int sourceLineNumber = -1;
     private String sourceFileName;
@@ -151,6 +153,7 @@ public class ExtLogRecord extends LogRecord {
     private long processId = -1;
     private String sourceModuleName;
     private String sourceModuleVersion;
+    private Object marker;
 
     private void writeObject(ObjectOutputStream oos) throws IOException {
         copyAll();
@@ -171,6 +174,7 @@ public class ExtLogRecord extends LogRecord {
         processId = fields.get("processId", -1L);
         sourceModuleName = (String) fields.get("sourceModuleName", null);
         sourceModuleVersion = (String) fields.get("sourceModuleVersion", null);
+        marker = fields.get("marker", null);
     }
 
     /**
@@ -614,5 +618,16 @@ public class ExtLogRecord extends LogRecord {
      */
     public void setResourceBundleName(final String name) {
         super.setResourceBundleName(name);
+    }
+
+    /**
+     * Set the marker for this event. Markers are used mostly by SLF4J and Log4j.
+     */
+    public void setMarker(Object marker) {
+        this.marker = marker;
+    }
+
+    public Object getMarker() {
+        return marker;
     }
 }


### PR DESCRIPTION
Hi @dmlloyd, 

@jamezp pointed out to move https://github.com/jboss-logging/jboss-logmanager/pull/333 here, so please have a look and let's discuss. This change should be backward compatible (adding a new field). 

This new property will be used to propagate the Marker to the actual
logging library. Since both SLF4J and Log4j define a different Marker
class without any common interface, here an Object is used.

This is a proposal to be able to receive the SLF4J (or log4j) `Marker` instance in the actual logging "driver".  My use-case is to use it in a custom `JsonProvider` for quarkus:

```
@Singleton
public class MyJsonProvider implements JsonProvider {

    public void writeTo(JsonGenerator generator, ExtLogRecord event) throws IOException {
          if (event.getMetadata() instanceof org.slf4j.Marker) { 
               // special logic here
          }
    }
}
```

Also `slf4j-jboss-logmanager` should be adapted too (i.e. to avoid `MarkerIgnoringBase`):

```
 private void log(final Marker marker, final java.util.logging.Level level,  final String fqcn, final String message, final Throwable t, final Object[] params) {
        final ExtLogRecord rec = new ExtLogRecord(level, message, ExtLogRecord.FormatStyle.NO_FORMAT, fqcn);
        rec.setThrown(t);
        rec.setParameters(params);
        rec.setMarker(marker); <--- new code 
        logger.logRaw(rec);
    }
```



