### PR TITLE
Use timestamp as provided by log record when formatting JSON

### DIFF
--- a/src/main/java/org/jboss/logmanager/formatters/StructuredFormatter.java
+++ b/src/main/java/org/jboss/logmanager/formatters/StructuredFormatter.java
@@ -206,7 +206,7 @@ public abstract class StructuredFormatter extends ExtFormatter {
             before(generator, record);
 
             // Add the default structure
-            generator.add(getKey(Key.TIMESTAMP), dateTimeFormatter.format(Instant.ofEpochMilli(record.getMillis())))
+            generator.add(getKey(Key.TIMESTAMP), dateTimeFormatter.format(record.getInstant()))
                     .add(getKey(Key.SEQUENCE), record.getSequenceNumber())
                     .add(getKey(Key.LOGGER_CLASS_NAME), record.getLoggerClassName())
                     .add(getKey(Key.LOGGER_NAME), record.getLoggerName())


### PR DESCRIPTION
The log record provides a timestamp which is converted to text by a `DateTimeFormatter` instance. Instead of always truncating the timestamp to millisecond precision, the original timestamp is now given to the `DateTimeFormatter` so that it can format it however it wants. The default formatter is still `DateTimeFormatter.ISO_OFFSET_DATE_TIME`. For timestamps with sub-millisecond precision it will also include those fractional seconds in the formatted text representation (up to nanosecond precision).

Fixes #7